### PR TITLE
Feature - Scrape all links

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -12,6 +12,7 @@
     "no-plusplus": 0,
     "no-return-assign": 0,
     "consistent-return": 0,
-    "no-await-in-loop": 0
+    "no-await-in-loop": 0,
+    "prefer-promise-reject-errors": 0
   }
 }

--- a/docs/scrape.md
+++ b/docs/scrape.md
@@ -20,6 +20,8 @@ Options:
   --version                    Show version number                     [boolean]
   --help, -h                   Show help                               [boolean]
   --identifier, -i             Archive.org identifier to scrape [required]
+  --all                        Grab all the links, not just the dead ones
+                                                                       [boolean]
   --multi, -m, --part          Check to see if there is multiple parts available
                                                        [boolean] [default: true]
   --extension, -e, --ext       Extension of files to list
@@ -43,6 +45,8 @@ By default it will save the results to a text file in the directory you run the 
     * ex: `-i IdentBlue` would try to find `IdentBluePart2`, `IdentBluePart3`
     * This is the naming scheme for some of the ReDump posts
   * Disable by passing `--no-multi`
+* `--all` - Boolean
+  * Scrape all the links from an identifier, not just the disabled ones.
 
 ## TODO
 

--- a/src/commands/find/commonOptions.js
+++ b/src/commands/find/commonOptions.js
@@ -1,4 +1,5 @@
-module.exports = yargs => yargs
+module.exports = yargs =>
+  yargs
     .options("path", {
       alias: "p",
       type: "string",

--- a/src/commands/scrapeArchive.js
+++ b/src/commands/scrapeArchive.js
@@ -34,6 +34,10 @@ module.exports = {
         default: true,
         desc: "Check to see if there is multiple parts available"
       })
+      .options("all", {
+        type: "boolean",
+        desc: "Grab all the links, not just the dead ones"
+      })
       .options("extension", {
         alias: ["e", "ext"],
         type: "string || string[]",
@@ -69,6 +73,7 @@ function spinnerMessage(
 async function handler({
   identifier,
   multi,
+  all,
   extension,
   output,
   print,
@@ -102,6 +107,7 @@ async function handler({
 
   const results = await scrapeIndentifiers(identifiers, {
     searchReg,
+    all,
     multi,
     extension
   });
@@ -184,7 +190,7 @@ function getMultiPartUrls(identifier) {
 
 async function scrapeIndentifiers(
   identifiers,
-  { multi, extension, searchReg }
+  { multi, all, extension, searchReg }
 ) {
   return Promise.map(identifiers, async identifier => {
     spinnerMessage(c`{blue ${identifier}} - starting...`);
@@ -229,9 +235,10 @@ async function scrapeIndentifiers(
         try {
           spinnerMessage(c`scraping {cyan ${it}}...`);
           const result = await scrape(it, {
-            names: xray(".directory-listing-table__restricted-file", [
-              "td:first-child"
-            ])
+            names: xray(
+              `.directory-listing-table${all ? "" : "__restricted-file"}`,
+              ["td:first-child"]
+            )
           });
 
           const resultUrls = result.names

--- a/src/utils/cues.js
+++ b/src/utils/cues.js
@@ -1,6 +1,6 @@
 const c = require("chalk");
 const Promise = require("bluebird");
-const { basename, dirname } = require("path");
+const { basename } = require("path");
 const { prompt } = require("inquirer");
 
 const { regex: REGEX_TRACKS } = require("../commands/find/findMultiTrack");


### PR DESCRIPTION
Resolves #1 

I have added the ability to scrape all links from an identifier not just the dead ones.

```bash
romtool scrape-archive --all -i FakeIdentifier
```